### PR TITLE
fixed the issue #13 "Turning off a column disables the total at the bottom" and added GUI improvements. Also some code was reworked to implement taraniselsu's idea to split data processing and GUI

### DIFF
--- a/Source/MainWindow.cs
+++ b/Source/MainWindow.cs
@@ -50,6 +50,7 @@ namespace Tac
         private GUIStyle headerStyleTop;
         private GUIStyle headerStyle;
         private GUIStyle buttonStyle;
+        private GUIStyle deleteButtonStyle;
         private GUIStyle toggleButtonStyle;
         private GUIStyle versionStyle;
         private GUIStyle gridAreaStyle;
@@ -106,6 +107,34 @@ namespace Tac
             scrollPosition = GUILayout.BeginScrollView(scrollPosition);
             GUILayout.BeginHorizontal();
 
+            if (settings.showDeleteButtons)
+            {
+                GUILayout.BeginVertical();
+                GUILayout.Label("", headerStyleTop);
+                GUILayout.Label("", headerStyle);
+                foreach (PartStringInfo partInfo in PartInfos)
+                {
+                    if (partInfo.Part != EditorLogic.startPod)
+                    {
+                        bool toDelete = GUILayout.Button("X", deleteButtonStyle);
+                        if (toDelete)
+                        {
+                            partInfo.Part.parent.removeChild(partInfo.Part);
+                            Part CurrentSelectedPart = EditorLogic.fetch.PartSelected;
+                            EditorLogic.fetch.PartSelected = partInfo.Part;
+                            EditorLogic.fetch.DestroySelectedPart();
+                            EditorLogic.fetch.PartSelected = CurrentSelectedPart;
+                        }
+                    }
+                    else
+                    {
+                        //root part of ship
+                        GUILayout.Label("", labelStyle2);
+                    }
+                }
+                GUILayout.EndVertical();
+            }
+
             GUILayout.BeginVertical();
             GUILayout.Label("", headerStyleTop);
             GUILayout.Label("Part Name", headerStyle);
@@ -122,7 +151,6 @@ namespace Tac
                 {
                     partInfo.Part.SetHighlightDefault();
                 }
- 
             }
             GUILayout.EndVertical();
 
@@ -301,6 +329,10 @@ namespace Tac
                 buttonStyle.normal.textColor = Color.white;
                 buttonStyle.alignment = TextAnchor.MiddleLeft;
                 buttonStyle.padding = new RectOffset(6, 2, 4, 2);
+
+                deleteButtonStyle = new GUIStyle(buttonStyle);
+                deleteButtonStyle.normal.textColor = Color.red;
+                deleteButtonStyle.fontStyle = FontStyle.Bold;
 
                 toggleButtonStyle = new GUIStyle(GUI.skin.button);
                 toggleButtonStyle.wordWrap = false;

--- a/Source/MainWindow.cs
+++ b/Source/MainWindow.cs
@@ -126,97 +126,111 @@ namespace Tac
             {
                 GUILayout.BeginVertical();
                 GUILayout.Label("Mass", headerStyle, GUILayout.ExpandWidth(true));
+            }
                 foreach (Part part in parts)
                 {
                     if (part.PhysicsSignificance != 1 && part.name != "strutConnector" && part.name != "fuelLine" && !part.Modules.Contains("LaunchClamp"))
                     {
                         var mass = part.mass + part.GetResourceMass();
-                        GUILayout.Label(mass.ToString("#,##0.###"), labelStyle2, GUILayout.ExpandWidth(true));
+                        if (settings.showFullMass)
+                            GUILayout.Label(mass.ToString("#,##0.###"), labelStyle2, GUILayout.ExpandWidth(true));
                         totalFullMass += mass;
                     }
                     else
                     {
                         // the part is "physics-less" in-game, so ignore the mass
-                        GUILayout.Label("-", labelStyle2, GUILayout.ExpandWidth(true));
+                        if (settings.showFullMass)
+                            GUILayout.Label("-", labelStyle2, GUILayout.ExpandWidth(true));
                     }
                 }
+            if (settings.showFullMass)
                 GUILayout.EndVertical();
-            }
 
             if (settings.showResourceMass)
             {
                 GUILayout.BeginVertical();
                 GUILayout.Label("Resource Mass", headerStyle, GUILayout.ExpandWidth(true));
+            }
                 foreach (Part part in parts)
                 {
                     var mass = part.GetResourceMass();
-                    GUILayout.Label(mass.ToString("#,##0.###"), labelStyle2, GUILayout.ExpandWidth(true));
+                    if (settings.showResourceMass)
+                        GUILayout.Label(mass.ToString("#,##0.###"), labelStyle2, GUILayout.ExpandWidth(true));
                     totalResourceMass += mass;
                 }
+            if (settings.showResourceMass)
                 GUILayout.EndVertical();
-            }
 
             if (settings.showEmptyMass)
             {
                 GUILayout.BeginVertical();
                 GUILayout.Label("Empty Mass", headerStyle, GUILayout.ExpandWidth(true));
+            }
                 foreach (Part part in parts)
                 {
                     if (part.PhysicsSignificance != 1 && part.name != "strutConnector" && part.name != "fuelLine" && !part.Modules.Contains("LaunchClamp"))
                     {
                         var mass = part.mass;
-                        GUILayout.Label(mass.ToString("#,##0.###"), labelStyle2, GUILayout.ExpandWidth(true));
+                        if (settings.showEmptyMass)
+                            GUILayout.Label(mass.ToString("#,##0.###"), labelStyle2, GUILayout.ExpandWidth(true));
                         totalEmptyMass += mass;
                     }
                     else
                     {
                         // the part is "physics-less" in-game, so ignore the mass
-                        GUILayout.Label("-", labelStyle2, GUILayout.ExpandWidth(true));
+                        if (settings.showEmptyMass)
+                            GUILayout.Label("-", labelStyle2, GUILayout.ExpandWidth(true));
                     }
                 }
+            if (settings.showEmptyMass)
                 GUILayout.EndVertical();
-            }
 
             if (settings.showFullCost)
             {
                 GUILayout.BeginVertical();
                 GUILayout.Label("Cost", headerStyle, GUILayout.ExpandWidth(true));
+            }
                 foreach (Part part in parts)
                 {
                     double missingResourcesCost = part.Resources.list.Sum(r => (r.maxAmount - r.amount) * r.info.unitCost);
                     double partCost = part.partInfo.cost + part.GetModuleCosts() - missingResourcesCost;
-                    GUILayout.Label(partCost.ToString("#,##0.##"), labelStyle2, GUILayout.ExpandWidth(true));
+                    if (settings.showFullCost)
+                        GUILayout.Label(partCost.ToString("#,##0.##"), labelStyle2, GUILayout.ExpandWidth(true));
                     totalFullCost += partCost;
                 }
+            if (settings.showFullCost)
                 GUILayout.EndVertical();
-            }
 
             if (settings.showResourceCost)
             {
                 GUILayout.BeginVertical();
                 GUILayout.Label("Resource Cost", headerStyle, GUILayout.ExpandWidth(true));
+            }
                 foreach (Part part in parts)
                 {
                     double resourceCost = part.Resources.list.Sum(r => r.amount * r.info.unitCost);
-                    GUILayout.Label(resourceCost.ToString("#,##0.##"), labelStyle2, GUILayout.ExpandWidth(true));
+                    if (settings.showResourceCost)
+                        GUILayout.Label(resourceCost.ToString("#,##0.##"), labelStyle2, GUILayout.ExpandWidth(true));
                     totalResourceCost += resourceCost;
                 }
+            if (settings.showResourceCost)
                 GUILayout.EndVertical();
-            }
 
             if (settings.showEmptyCost)
             {
                 GUILayout.BeginVertical();
                 GUILayout.Label("Empty Cost", headerStyle, GUILayout.ExpandWidth(true));
+            }
                 foreach (Part part in parts)
                 {
                     double maxResourceCost = part.Resources.list.Sum(r => r.maxAmount * r.info.unitCost);
                     double emptyPartCost = part.partInfo.cost + part.GetModuleCosts() - maxResourceCost;
-                    GUILayout.Label(emptyPartCost.ToString("#,##0.##"), labelStyle2, GUILayout.ExpandWidth(true));
+                    if (settings.showEmptyCost)
+                        GUILayout.Label(emptyPartCost.ToString("#,##0.##"), labelStyle2, GUILayout.ExpandWidth(true));
                     totalEmptyCost += emptyPartCost;
                 }
+            if (settings.showEmptyCost)
                 GUILayout.EndVertical();
-            }
 
             GUILayout.EndHorizontal();
             GUILayout.EndScrollView();

--- a/Source/MainWindow.cs
+++ b/Source/MainWindow.cs
@@ -45,10 +45,12 @@ namespace Tac
 
         private GUIStyle labelStyle;
         private GUIStyle labelStyle2;
+        private GUIStyle headerStyleTop;
         private GUIStyle headerStyle;
         private GUIStyle buttonStyle;
         private GUIStyle toggleButtonStyle;
         private GUIStyle versionStyle;
+        private GUIStyle gridAreaStyle;
 
         public MainWindow(Settings settings, SettingsWindow settingsWindow)
             : base("TAC Part Lister", 360, Screen.height * 0.6f)
@@ -88,6 +90,7 @@ namespace Tac
             GUILayout.BeginHorizontal();
 
             GUILayout.BeginVertical();
+            GUILayout.Label("", headerStyleTop);
             GUILayout.Label("Part Name", headerStyle);
             foreach (Part part in parts)
             {
@@ -114,6 +117,7 @@ namespace Tac
             if (settings.showStage)
             {
                 GUILayout.BeginVertical();
+                GUILayout.Label("", headerStyleTop);
                 GUILayout.Label("Stage", headerStyle, GUILayout.ExpandWidth(true));
                 foreach (Part part in parts)
                 {
@@ -122,10 +126,22 @@ namespace Tac
                 GUILayout.EndVertical();
             }
 
+            bool showMassArea = settings.showFullMass || settings.showResourceMass || settings.showEmptyMass;
+            if (showMassArea)
+            {
+                //Mass grid area
+                if (settings.highlightGridAreas)
+                    GUILayout.BeginVertical(gridAreaStyle, GUILayout.ExpandHeight(true));
+                else
+                    GUILayout.BeginVertical();
+                GUILayout.Label("Mass", headerStyleTop, GUILayout.ExpandWidth(true));
+                GUILayout.BeginHorizontal();
+            }
+
             if (settings.showFullMass)
             {
                 GUILayout.BeginVertical();
-                GUILayout.Label("Mass", headerStyle, GUILayout.ExpandWidth(true));
+                GUILayout.Label("Wet", headerStyle, GUILayout.ExpandWidth(true));
             }
             foreach (Part part in parts)
             {
@@ -149,7 +165,7 @@ namespace Tac
             if (settings.showResourceMass)
             {
                 GUILayout.BeginVertical();
-                GUILayout.Label("Resource Mass", headerStyle, GUILayout.ExpandWidth(true));
+                GUILayout.Label("Res.", headerStyle, GUILayout.ExpandWidth(true));
             }
             foreach (Part part in parts)
             {
@@ -164,7 +180,7 @@ namespace Tac
             if (settings.showEmptyMass)
             {
                 GUILayout.BeginVertical();
-                GUILayout.Label("Empty Mass", headerStyle, GUILayout.ExpandWidth(true));
+                GUILayout.Label("Dry", headerStyle, GUILayout.ExpandWidth(true));
             }
             foreach (Part part in parts)
             {
@@ -185,10 +201,28 @@ namespace Tac
             if (settings.showEmptyMass)
                 GUILayout.EndVertical();
 
+            if (showMassArea)
+            {
+                GUILayout.EndHorizontal();
+                GUILayout.EndVertical(); //Mass grid area
+            }
+
+            bool showCostArea = settings.showFullCost || settings.showResourceCost || settings.showEmptyCost;
+            if (showCostArea)
+            {
+                //Cost grid area
+                if (settings.highlightGridAreas)
+                    GUILayout.BeginVertical(gridAreaStyle, GUILayout.ExpandHeight(true));
+                else
+                    GUILayout.BeginVertical();
+                GUILayout.Label("Cost", headerStyleTop, GUILayout.ExpandWidth(true));
+                GUILayout.BeginHorizontal();
+            }
+
             if (settings.showFullCost)
             {
                 GUILayout.BeginVertical();
-                GUILayout.Label("Cost", headerStyle, GUILayout.ExpandWidth(true));
+                GUILayout.Label("Total", headerStyle, GUILayout.ExpandWidth(true));
             }
             foreach (Part part in parts)
             {
@@ -204,7 +238,7 @@ namespace Tac
             if (settings.showResourceCost)
             {
                 GUILayout.BeginVertical();
-                GUILayout.Label("Resource Cost", headerStyle, GUILayout.ExpandWidth(true));
+                GUILayout.Label("Res.", headerStyle, GUILayout.ExpandWidth(true));
             }
             foreach (Part part in parts)
             {
@@ -219,7 +253,7 @@ namespace Tac
             if (settings.showEmptyCost)
             {
                 GUILayout.BeginVertical();
-                GUILayout.Label("Empty Cost", headerStyle, GUILayout.ExpandWidth(true));
+                GUILayout.Label("Part", headerStyle, GUILayout.ExpandWidth(true));
             }
             foreach (Part part in parts)
             {
@@ -232,12 +266,18 @@ namespace Tac
             if (settings.showEmptyCost)
                 GUILayout.EndVertical();
 
+            if (showCostArea)
+            {
+                GUILayout.EndHorizontal();
+                GUILayout.EndVertical(); //Cost grid area
+            }
+
             GUILayout.EndHorizontal();
             GUILayout.EndScrollView();
 
             GUILayout.Space(2);
             GUILayout.Label("Parts: " + parts.Count.ToString(), labelStyle);
-            GUILayout.Label("Mass: total: " + totalFullMass.ToString("#,##0.###") + ", resources: " + totalResourceMass.ToString("#,##0.###") + ", empty: " + totalEmptyMass.ToString("#,##0.###"), labelStyle);
+            GUILayout.Label("Mass: wet: " + totalFullMass.ToString("#,##0.###") + ", resources: " + totalResourceMass.ToString("#,##0.###") + ",   dry: " + totalEmptyMass.ToString("#,##0.###"), labelStyle);
             GUILayout.Label("Cost: total: " + totalFullCost.ToString("#,##0.##") + ", resources: " + totalResourceCost.ToString("#,##0.##") + ", empty: " + totalEmptyCost.ToString("#,##0.##"), labelStyle);
 
             showResources = GUILayout.Toggle(showResources, "Show resources", toggleButtonStyle, GUILayout.ExpandWidth(false));
@@ -285,6 +325,10 @@ namespace Tac
                 headerStyle.fontStyle = FontStyle.Bold;
                 headerStyle.normal.textColor = Color.white;
                 headerStyle.alignment = TextAnchor.MiddleCenter;
+                headerStyle.padding.top = 0;
+
+                headerStyleTop = new GUIStyle(headerStyle);
+                headerStyleTop.padding.bottom = 0;
 
                 buttonStyle = new GUIStyle(GUI.skin.button);
                 buttonStyle.wordWrap = false;
@@ -304,6 +348,8 @@ namespace Tac
                 toggleButtonStyle.padding.bottom = 1;
 
                 versionStyle = Utilities.GetVersionStyle();
+
+                gridAreaStyle = new GUIStyle(GUI.skin.scrollView);
             }
         }
 

--- a/Source/MainWindow.cs
+++ b/Source/MainWindow.cs
@@ -129,7 +129,7 @@ namespace Tac
                     else
                     {
                         //root part of ship
-                        GUILayout.Label("", labelStyle2);
+                        GUILayout.Label("", deleteButtonStyle);
                     }
                 }
                 GUILayout.EndVertical();

--- a/Source/MainWindow.cs
+++ b/Source/MainWindow.cs
@@ -127,22 +127,22 @@ namespace Tac
                 GUILayout.BeginVertical();
                 GUILayout.Label("Mass", headerStyle, GUILayout.ExpandWidth(true));
             }
-                foreach (Part part in parts)
+            foreach (Part part in parts)
+            {
+                if (part.PhysicsSignificance != 1 && part.name != "strutConnector" && part.name != "fuelLine" && !part.Modules.Contains("LaunchClamp"))
                 {
-                    if (part.PhysicsSignificance != 1 && part.name != "strutConnector" && part.name != "fuelLine" && !part.Modules.Contains("LaunchClamp"))
-                    {
-                        var mass = part.mass + part.GetResourceMass();
-                        if (settings.showFullMass)
-                            GUILayout.Label(mass.ToString("#,##0.###"), labelStyle2, GUILayout.ExpandWidth(true));
-                        totalFullMass += mass;
-                    }
-                    else
-                    {
-                        // the part is "physics-less" in-game, so ignore the mass
-                        if (settings.showFullMass)
-                            GUILayout.Label("-", labelStyle2, GUILayout.ExpandWidth(true));
-                    }
+                    var mass = part.mass + part.GetResourceMass();
+                    if (settings.showFullMass)
+                        GUILayout.Label(mass.ToString("#,##0.###"), labelStyle2, GUILayout.ExpandWidth(true));
+                    totalFullMass += mass;
                 }
+                else
+                {
+                    // the part is "physics-less" in-game, so ignore the mass
+                    if (settings.showFullMass)
+                        GUILayout.Label("-", labelStyle2, GUILayout.ExpandWidth(true));
+                }
+            }
             if (settings.showFullMass)
                 GUILayout.EndVertical();
 
@@ -151,13 +151,13 @@ namespace Tac
                 GUILayout.BeginVertical();
                 GUILayout.Label("Resource Mass", headerStyle, GUILayout.ExpandWidth(true));
             }
-                foreach (Part part in parts)
-                {
-                    var mass = part.GetResourceMass();
-                    if (settings.showResourceMass)
-                        GUILayout.Label(mass.ToString("#,##0.###"), labelStyle2, GUILayout.ExpandWidth(true));
-                    totalResourceMass += mass;
-                }
+            foreach (Part part in parts)
+            {
+                var mass = part.GetResourceMass();
+                if (settings.showResourceMass)
+                    GUILayout.Label(mass.ToString("#,##0.###"), labelStyle2, GUILayout.ExpandWidth(true));
+                totalResourceMass += mass;
+            }
             if (settings.showResourceMass)
                 GUILayout.EndVertical();
 
@@ -166,22 +166,22 @@ namespace Tac
                 GUILayout.BeginVertical();
                 GUILayout.Label("Empty Mass", headerStyle, GUILayout.ExpandWidth(true));
             }
-                foreach (Part part in parts)
+            foreach (Part part in parts)
+            {
+                if (part.PhysicsSignificance != 1 && part.name != "strutConnector" && part.name != "fuelLine" && !part.Modules.Contains("LaunchClamp"))
                 {
-                    if (part.PhysicsSignificance != 1 && part.name != "strutConnector" && part.name != "fuelLine" && !part.Modules.Contains("LaunchClamp"))
-                    {
-                        var mass = part.mass;
-                        if (settings.showEmptyMass)
-                            GUILayout.Label(mass.ToString("#,##0.###"), labelStyle2, GUILayout.ExpandWidth(true));
-                        totalEmptyMass += mass;
-                    }
-                    else
-                    {
-                        // the part is "physics-less" in-game, so ignore the mass
-                        if (settings.showEmptyMass)
-                            GUILayout.Label("-", labelStyle2, GUILayout.ExpandWidth(true));
-                    }
+                    var mass = part.mass;
+                    if (settings.showEmptyMass)
+                        GUILayout.Label(mass.ToString("#,##0.###"), labelStyle2, GUILayout.ExpandWidth(true));
+                    totalEmptyMass += mass;
                 }
+                else
+                {
+                    // the part is "physics-less" in-game, so ignore the mass
+                    if (settings.showEmptyMass)
+                        GUILayout.Label("-", labelStyle2, GUILayout.ExpandWidth(true));
+                }
+            }
             if (settings.showEmptyMass)
                 GUILayout.EndVertical();
 
@@ -190,14 +190,14 @@ namespace Tac
                 GUILayout.BeginVertical();
                 GUILayout.Label("Cost", headerStyle, GUILayout.ExpandWidth(true));
             }
-                foreach (Part part in parts)
-                {
-                    double missingResourcesCost = part.Resources.list.Sum(r => (r.maxAmount - r.amount) * r.info.unitCost);
-                    double partCost = part.partInfo.cost + part.GetModuleCosts() - missingResourcesCost;
-                    if (settings.showFullCost)
-                        GUILayout.Label(partCost.ToString("#,##0.##"), labelStyle2, GUILayout.ExpandWidth(true));
-                    totalFullCost += partCost;
-                }
+            foreach (Part part in parts)
+            {
+                double missingResourcesCost = part.Resources.list.Sum(r => (r.maxAmount - r.amount) * r.info.unitCost);
+                double partCost = part.partInfo.cost + part.GetModuleCosts() - missingResourcesCost;
+                if (settings.showFullCost)
+                    GUILayout.Label(partCost.ToString("#,##0.##"), labelStyle2, GUILayout.ExpandWidth(true));
+                totalFullCost += partCost;
+            }
             if (settings.showFullCost)
                 GUILayout.EndVertical();
 
@@ -206,13 +206,13 @@ namespace Tac
                 GUILayout.BeginVertical();
                 GUILayout.Label("Resource Cost", headerStyle, GUILayout.ExpandWidth(true));
             }
-                foreach (Part part in parts)
-                {
-                    double resourceCost = part.Resources.list.Sum(r => r.amount * r.info.unitCost);
-                    if (settings.showResourceCost)
-                        GUILayout.Label(resourceCost.ToString("#,##0.##"), labelStyle2, GUILayout.ExpandWidth(true));
-                    totalResourceCost += resourceCost;
-                }
+            foreach (Part part in parts)
+            {
+                double resourceCost = part.Resources.list.Sum(r => r.amount * r.info.unitCost);
+                if (settings.showResourceCost)
+                    GUILayout.Label(resourceCost.ToString("#,##0.##"), labelStyle2, GUILayout.ExpandWidth(true));
+                totalResourceCost += resourceCost;
+            }
             if (settings.showResourceCost)
                 GUILayout.EndVertical();
 
@@ -221,14 +221,14 @@ namespace Tac
                 GUILayout.BeginVertical();
                 GUILayout.Label("Empty Cost", headerStyle, GUILayout.ExpandWidth(true));
             }
-                foreach (Part part in parts)
-                {
-                    double maxResourceCost = part.Resources.list.Sum(r => r.maxAmount * r.info.unitCost);
-                    double emptyPartCost = part.partInfo.cost + part.GetModuleCosts() - maxResourceCost;
-                    if (settings.showEmptyCost)
-                        GUILayout.Label(emptyPartCost.ToString("#,##0.##"), labelStyle2, GUILayout.ExpandWidth(true));
-                    totalEmptyCost += emptyPartCost;
-                }
+            foreach (Part part in parts)
+            {
+                double maxResourceCost = part.Resources.list.Sum(r => r.maxAmount * r.info.unitCost);
+                double emptyPartCost = part.partInfo.cost + part.GetModuleCosts() - maxResourceCost;
+                if (settings.showEmptyCost)
+                    GUILayout.Label(emptyPartCost.ToString("#,##0.##"), labelStyle2, GUILayout.ExpandWidth(true));
+                totalEmptyCost += emptyPartCost;
+            }
             if (settings.showEmptyCost)
                 GUILayout.EndVertical();
 

--- a/Source/MainWindow.cs
+++ b/Source/MainWindow.cs
@@ -397,6 +397,11 @@ namespace Tac
                 float mass;
                 double cost;
 
+                //some parts doesn't contain any resource
+                //or has maxAmount of all resources equals to 0 (for example the electricity generators or consumers of fuel, such as engines)
+                bool isResourceContainer = ((part.Resources.Count > 0) &&
+                                            (part.Resources.list.Sum(r => (float)r.maxAmount) > 0.001));
+
                 partInfo.Part = part;
 
                 partInfo.NameLabel = part.partInfo.title;
@@ -420,9 +425,17 @@ namespace Tac
                     partInfo.FullMass = "-";
                 }
 
-                mass = part.GetResourceMass();
-                partInfo.ResourceMass = mass.ToString("#,##0.###");
-                totalResourceMass += mass;
+                if (isResourceContainer)
+                {
+                    mass = part.GetResourceMass();
+                    partInfo.ResourceMass = mass.ToString("#,##0.###");
+                    totalResourceMass += mass;
+                }
+                else
+                {
+                    // the part has no resources
+                    partInfo.ResourceMass = "-";
+                }
 
                 if (!IsPartPhysicsLess(part))
                 {
@@ -442,9 +455,17 @@ namespace Tac
                 partInfo.FullCost = cost.ToString("#,##0.##");
                 totalFullCost += cost;
 
-                cost = part.Resources.list.Sum(r => r.amount * r.info.unitCost);
-                partInfo.ResourceCost = cost.ToString("#,##0.##");
-                totalResourceCost += cost;
+                if (isResourceContainer)
+                {
+                    cost = part.Resources.list.Sum(r => r.amount * r.info.unitCost);
+                    partInfo.ResourceCost = cost.ToString("#,##0.##");
+                    totalResourceCost += cost;
+                }
+                else
+                {
+                    // the part has no resources
+                    partInfo.ResourceCost = "-";
+                }
 
                 double maxResourceCost = part.Resources.list.Sum(r => r.maxAmount * r.info.unitCost);
                 cost = part.partInfo.cost + part.GetModuleCosts() - maxResourceCost;

--- a/Source/MainWindow.cs
+++ b/Source/MainWindow.cs
@@ -284,7 +284,7 @@ namespace Tac
 
             if (GUI.Button(new Rect(windowPos.width - 46, 4, 20, 20), "S", closeButtonStyle))
             {
-                settingsWindow.SetVisible(true);
+                settingsWindow.ToggleVisible();
             }
         }
 

--- a/Source/MainWindow.cs
+++ b/Source/MainWindow.cs
@@ -45,6 +45,8 @@ namespace Tac
 
         private GUIStyle labelStyle;
         private GUIStyle labelStyle2;
+        private GUIStyle labelStyleRes;
+        private GUIStyle labelStyleEmpty;
         private GUIStyle headerStyleTop;
         private GUIStyle headerStyle;
         private GUIStyle buttonStyle;
@@ -79,6 +81,8 @@ namespace Tac
             double totalFullCost = 0.0;
             double totalResourceCost = 0.0;
             double totalEmptyCost = 0.0;
+
+            SetColoredNumbers(settings.showColoredNumbers);
 
             var parts = new List<Part>(EditorLogic.fetch.ship.parts);
             parts.ForEach(part => part.UpdateOrgPosAndRot(part.localRoot));
@@ -171,7 +175,7 @@ namespace Tac
             {
                 var mass = part.GetResourceMass();
                 if (settings.showResourceMass)
-                    GUILayout.Label(mass.ToString("#,##0.###"), labelStyle2, GUILayout.ExpandWidth(true));
+                    GUILayout.Label(mass.ToString("#,##0.###"), labelStyleRes, GUILayout.ExpandWidth(true));
                 totalResourceMass += mass;
             }
             if (settings.showResourceMass)
@@ -188,7 +192,7 @@ namespace Tac
                 {
                     var mass = part.mass;
                     if (settings.showEmptyMass)
-                        GUILayout.Label(mass.ToString("#,##0.###"), labelStyle2, GUILayout.ExpandWidth(true));
+                        GUILayout.Label(mass.ToString("#,##0.###"), labelStyleEmpty, GUILayout.ExpandWidth(true));
                     totalEmptyMass += mass;
                 }
                 else
@@ -244,7 +248,7 @@ namespace Tac
             {
                 double resourceCost = part.Resources.list.Sum(r => r.amount * r.info.unitCost);
                 if (settings.showResourceCost)
-                    GUILayout.Label(resourceCost.ToString("#,##0.##"), labelStyle2, GUILayout.ExpandWidth(true));
+                    GUILayout.Label(resourceCost.ToString("#,##0.##"), labelStyleRes, GUILayout.ExpandWidth(true));
                 totalResourceCost += resourceCost;
             }
             if (settings.showResourceCost)
@@ -260,7 +264,7 @@ namespace Tac
                 double maxResourceCost = part.Resources.list.Sum(r => r.maxAmount * r.info.unitCost);
                 double emptyPartCost = part.partInfo.cost + part.GetModuleCosts() - maxResourceCost;
                 if (settings.showEmptyCost)
-                    GUILayout.Label(emptyPartCost.ToString("#,##0.##"), labelStyle2, GUILayout.ExpandWidth(true));
+                    GUILayout.Label(emptyPartCost.ToString("#,##0.##"), labelStyleEmpty, GUILayout.ExpandWidth(true));
                 totalEmptyCost += emptyPartCost;
             }
             if (settings.showEmptyCost)
@@ -320,6 +324,9 @@ namespace Tac
                 labelStyle2.normal.textColor = Color.white;
                 labelStyle2.alignment = TextAnchor.MiddleRight;
 
+                labelStyleRes = new GUIStyle(labelStyle2);
+                labelStyleEmpty = new GUIStyle(labelStyle2);
+
                 headerStyle = new GUIStyle(GUI.skin.label);
                 headerStyle.wordWrap = false;
                 headerStyle.fontStyle = FontStyle.Bold;
@@ -329,6 +336,7 @@ namespace Tac
 
                 headerStyleTop = new GUIStyle(headerStyle);
                 headerStyleTop.padding.bottom = 0;
+//                headerStyleTop.margin.bottom = 0;
 
                 buttonStyle = new GUIStyle(GUI.skin.button);
                 buttonStyle.wordWrap = false;
@@ -350,6 +358,20 @@ namespace Tac
                 versionStyle = Utilities.GetVersionStyle();
 
                 gridAreaStyle = new GUIStyle(GUI.skin.scrollView);
+            }
+        }
+
+        private void SetColoredNumbers(bool ColoredNumbers)
+        {
+            if (ColoredNumbers)
+            {
+                labelStyleRes.normal.textColor = Color.yellow + Color.gray * 1.5f;
+                labelStyleEmpty.normal.textColor = Color.cyan      + Color.gray * 1.5f;
+            }
+            else
+            {
+                labelStyleRes.normal.textColor = Color.white;
+                labelStyleEmpty.normal.textColor = Color.white;
             }
         }
 

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.3")]
-[assembly: AssemblyFileVersion("1.3.0.3")]
+[assembly: AssemblyVersion("1.3.0.4")]
+[assembly: AssemblyFileVersion("1.3.0.4")]

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.2")]
-[assembly: AssemblyFileVersion("1.3.0.2")]
+[assembly: AssemblyVersion("1.3.0.3")]
+[assembly: AssemblyFileVersion("1.3.0.3")]

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.1")]
-[assembly: AssemblyFileVersion("1.3.0.1")]
+[assembly: AssemblyVersion("1.3.0.2")]
+[assembly: AssemblyFileVersion("1.3.0.2")]

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.4")]
-[assembly: AssemblyFileVersion("1.3.0.4")]
+[assembly: AssemblyVersion("1.3.0.5")]
+[assembly: AssemblyFileVersion("1.3.0.5")]

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.3.0.1")]
+[assembly: AssemblyFileVersion("1.3.0.1")]

--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -42,6 +42,7 @@ namespace Tac
         internal bool showResourceCost { get; set; }
         internal bool showEmptyCost { get; set; }
         internal bool highlightGridAreas { get; set; }
+        internal bool showColoredNumbers { get; set; }
 
         internal Settings()
         {
@@ -53,6 +54,7 @@ namespace Tac
             showResourceCost = true;
             showEmptyCost = true;
             highlightGridAreas = true;
+            showColoredNumbers = true;
         }
 
         internal void Load(ConfigNode config)
@@ -65,6 +67,7 @@ namespace Tac
             showResourceCost = Utilities.GetValue(config, "showResourceCost", showResourceCost);
             showEmptyCost = Utilities.GetValue(config, "showEmptyCost", showEmptyCost);
             highlightGridAreas = Utilities.GetValue(config, "highlightGridAreas", highlightGridAreas);
+            showColoredNumbers = Utilities.GetValue(config, "showColoredNumbers", showColoredNumbers);
         }
 
         internal void Save(ConfigNode config)
@@ -77,6 +80,7 @@ namespace Tac
             config.AddValue("showResourceCost", showResourceCost);
             config.AddValue("showEmptyCost", showEmptyCost);
             config.AddValue("highlightGridAreas", highlightGridAreas);
+            config.AddValue("showColoredNumbers", showColoredNumbers);
         }
     }
 }

--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -41,6 +41,7 @@ namespace Tac
         internal bool showFullCost { get; set; }
         internal bool showResourceCost { get; set; }
         internal bool showEmptyCost { get; set; }
+        internal bool highlightGridAreas { get; set; }
 
         internal Settings()
         {
@@ -51,6 +52,7 @@ namespace Tac
             showFullCost = true;
             showResourceCost = true;
             showEmptyCost = true;
+            highlightGridAreas = true;
         }
 
         internal void Load(ConfigNode config)
@@ -62,6 +64,7 @@ namespace Tac
             showFullCost = Utilities.GetValue(config, "showFullCost", showFullCost);
             showResourceCost = Utilities.GetValue(config, "showResourceCost", showResourceCost);
             showEmptyCost = Utilities.GetValue(config, "showEmptyCost", showEmptyCost);
+            highlightGridAreas = Utilities.GetValue(config, "highlightGridAreas", highlightGridAreas);
         }
 
         internal void Save(ConfigNode config)
@@ -73,6 +76,7 @@ namespace Tac
             config.AddValue("showFullCost", showFullCost);
             config.AddValue("showResourceCost", showResourceCost);
             config.AddValue("showEmptyCost", showEmptyCost);
+            config.AddValue("highlightGridAreas", highlightGridAreas);
         }
     }
 }

--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -43,6 +43,7 @@ namespace Tac
         internal bool showEmptyCost { get; set; }
         internal bool highlightGridAreas { get; set; }
         internal bool showColoredNumbers { get; set; }
+        internal bool showDeleteButtons { get; set; }
 
         internal Settings()
         {
@@ -55,6 +56,7 @@ namespace Tac
             showEmptyCost = true;
             highlightGridAreas = true;
             showColoredNumbers = true;
+            showDeleteButtons = true;
         }
 
         internal void Load(ConfigNode config)
@@ -68,6 +70,7 @@ namespace Tac
             showEmptyCost = Utilities.GetValue(config, "showEmptyCost", showEmptyCost);
             highlightGridAreas = Utilities.GetValue(config, "highlightGridAreas", highlightGridAreas);
             showColoredNumbers = Utilities.GetValue(config, "showColoredNumbers", showColoredNumbers);
+            showDeleteButtons = Utilities.GetValue(config, "showDeleteButtons", showDeleteButtons);
         }
 
         internal void Save(ConfigNode config)
@@ -81,6 +84,7 @@ namespace Tac
             config.AddValue("showEmptyCost", showEmptyCost);
             config.AddValue("highlightGridAreas", highlightGridAreas);
             config.AddValue("showColoredNumbers", showColoredNumbers);
+            config.AddValue("showDeleteButtons", showDeleteButtons);
         }
     }
 }

--- a/Source/SettingsWindow.cs
+++ b/Source/SettingsWindow.cs
@@ -66,6 +66,7 @@ namespace Tac
             settings.showFullCost = GUILayout.Toggle(settings.showFullCost, "Show Full Cost");
             settings.showResourceCost = GUILayout.Toggle(settings.showResourceCost, "Show Resource Cost");
             settings.showEmptyCost = GUILayout.Toggle(settings.showEmptyCost, "Show Empty Cost");
+            settings.highlightGridAreas = GUILayout.Toggle(settings.highlightGridAreas, "Highlight Mass & Cost areas");
 
             GUILayout.EndVertical();
 

--- a/Source/SettingsWindow.cs
+++ b/Source/SettingsWindow.cs
@@ -59,6 +59,7 @@ namespace Tac
         {
             GUILayout.BeginVertical();
 
+            settings.showDeleteButtons = GUILayout.Toggle(settings.showDeleteButtons, "Show \"Delete\" Buttons");
             settings.showStage = GUILayout.Toggle(settings.showStage, "Show Stage Number");
             settings.showFullMass = GUILayout.Toggle(settings.showFullMass, "Show Full Mass");
             settings.showResourceMass = GUILayout.Toggle(settings.showResourceMass, "Show Resource Mass");

--- a/Source/SettingsWindow.cs
+++ b/Source/SettingsWindow.cs
@@ -67,6 +67,7 @@ namespace Tac
             settings.showResourceCost = GUILayout.Toggle(settings.showResourceCost, "Show Resource Cost");
             settings.showEmptyCost = GUILayout.Toggle(settings.showEmptyCost, "Show Empty Cost");
             settings.highlightGridAreas = GUILayout.Toggle(settings.highlightGridAreas, "Highlight Mass & Cost areas");
+            settings.showColoredNumbers = GUILayout.Toggle(settings.showColoredNumbers, "Show Colored Numbers");
 
             GUILayout.EndVertical();
 

--- a/Source/TacPartLister.cs
+++ b/Source/TacPartLister.cs
@@ -63,6 +63,9 @@ namespace Tac
             Load();
 
             button.Visible = true;
+
+            GameEvents.onEditorShipModified.Add(OnEditorShipModified);
+            GameEvents.onLevelWasLoaded.Add(OnLevelWasLoaded);
         }
 
         void Update()
@@ -89,6 +92,9 @@ namespace Tac
             this.Log("OnDestroy");
             Save();
             button.Destroy();
+
+            GameEvents.onEditorShipModified.Remove(OnEditorShipModified);
+            GameEvents.onLevelWasLoaded.Remove(OnLevelWasLoaded);
 
             // Make sure we remove our locks
             if (InputLockManager.GetControlLock(lockName) == desiredLock)
@@ -123,6 +129,19 @@ namespace Tac
         private void OnIconClicked()
         {
             window.ToggleVisible();
+        }
+
+        private void OnEditorShipModified(ShipConstruct shipConstruct)
+        {
+            this.Log("OnEditorShipModified - shipConstruct: " + shipConstruct);
+            window.RefreshPartInfos(shipConstruct.parts);
+            // may be EditorLogic.fetch.ship.parts , not shipConstruct.parts ? I'm not sure. It seems to me that it doesn't matter
+        }
+
+        private void OnLevelWasLoaded(GameScenes gameScene)
+        {
+            this.Log("Game scene loaded: " + gameScene);
+            window.RefreshPartInfos(EditorLogic.fetch.ship.parts);
         }
     }
 }


### PR DESCRIPTION
Fixed the issue #13 "Turning off a column disables the total at the bottom" and fixes version number

Added some GUI Improvements:
- Values of Mass and Cost grouped together
- grouped areas can be highlighted
- words "Full" and "Empty" changed to "Wet" and "Dry" in Mass headers

![2014-11-14 00-06-20 kerbal space program](https://cloud.githubusercontent.com/assets/6450733/5036996/3d941f00-6b95-11e4-8cc6-d0e61e6b6c89.png)
- numbers in "Res." and "Dry/Empty" columns can be colored

![2014-11-14 00-17-49 kerbal space program](https://cloud.githubusercontent.com/assets/6450733/5037011/51ddd370-6b95-11e4-853f-459550d84a26.png)

![2014-11-14 00-18-30 kerbal space program](https://cloud.githubusercontent.com/assets/6450733/5037013/55c8ddb8-6b95-11e4-99f1-e4f00d630230.png)

![2014-11-14 00-19-08 kerbal space program](https://cloud.githubusercontent.com/assets/6450733/5037014/580e9752-6b95-11e4-990b-36b557b7b8af.png)
